### PR TITLE
xDAI/Rinkeby support

### DIFF
--- a/src/components/Batch.tsx
+++ b/src/components/Batch.tsx
@@ -18,6 +18,7 @@ import {
   BATCH_DURATION,
   BatchSolutions,
   batchDate,
+  TX_EXPLORER,
 } from "../models/exchange";
 import { formatTime, formatTx } from "../utilities/format";
 
@@ -65,7 +66,7 @@ export interface BatchProps {
 
 const LINK_UPDATE_INTERVAL = 5000;
 
-function Batch({ batch, solutions }: BatchSolutions) {
+function Batch({ batch, network, solutions }: BatchSolutions) {
   const classes = useStyles();
   const [link, setLink] = useState(undefined as string | undefined);
   const [solver, setSolver] = useState(undefined as ResultData | undefined);
@@ -114,7 +115,7 @@ function Batch({ batch, solutions }: BatchSolutions) {
           ) : (
             <span>
               Tx{" "}
-              <a href={`https://etherscan.io/tx/${solutions![0].txHash}`}>
+              <a href={`${TX_EXPLORER[network]}${solutions![0].txHash}`}>
                 {formatTx(solutions![0].txHash)}
               </a>
             </span>

--- a/src/models/bucket.ts
+++ b/src/models/bucket.ts
@@ -106,6 +106,30 @@ const SOLVERS: Record<string, SolverData | undefined> = {
     name: "Production Best-Ring Solver",
     path: "mainnet_prod/best-ring-solver",
   },
+  "0x122085960fe0124569cb99211e6dfad082a10f92": {
+    name: "Staging Best-Ring Solver (xDAI)",
+    path: "xdai_dev/best-ring-solver",
+  },
+  "0x03e941626aacd9f088a5d24479f22f2e87045cda": {
+    name: "Staging Standard Solver (xDAI)",
+    path: "xdai_dev/standard-solver",
+  },
+  "0x66651c3136f45f5a3f216bdcf794246bdf92163e": {
+    name: "Staging Open Solver (xDAI)",
+    path: "xdai_dev/open-solver",
+  },
+  "0xa800b730ca1270a3db0d23c4643363fe795e2fe6": {
+    name: "Staging Best-Ring Solver (Rinkeby)",
+    path: "rinkeby_dev/best-ring-solver",
+  },
+  "0x3851195b21d672e88bbd45f0da94e1d14b755339": {
+    name: "Staging Standard Solver (Rinkeby)",
+    path: "rinkeby_dev/standard-solver",
+  },
+  "0x8bda84af06bd413f7e47fcbff1b6474b91b41df2": {
+    name: "Staging Open Solver (Rinkeby)",
+    path: "rinkeby_dev/open-solver",
+  },
 };
 
 function getSolverByAddress(solverAddress: string): SolverData | undefined {

--- a/src/models/exchange.ts
+++ b/src/models/exchange.ts
@@ -47,7 +47,7 @@ export enum Network {
   Xdai = "xdai",
 }
 
-const GP_GRAPH: Record<Network, string | undefined> = {
+const GP_GRAPH: Record<Network, string> = {
   [Network.Mainnet]: "https://api.thegraph.com/subgraphs/name/gnosis/protocol",
   [Network.Rinkeby]:
     "https://api.thegraph.com/subgraphs/name/gnosis/protocol-rinkeby",
@@ -55,7 +55,7 @@ const GP_GRAPH: Record<Network, string | undefined> = {
     "https://api.thegraph.com/subgraphs/name/gnosis/protocol-xdai",
 };
 
-export const TX_EXPLORER: Record<Network, string | undefined> = {
+export const TX_EXPLORER: Record<Network, string> = {
   [Network.Mainnet]: "https://etherscan.io/tx/",
   [Network.Rinkeby]: "https://rinkeby.etherscan.io/tx/",
   [Network.Xdai]: "https://blockscout.com/poa/xdai/tx/",
@@ -85,7 +85,7 @@ export async function getLatestBatchSolutions(
     ? `first: ${count}`
     : `where: {id_gt: "${solvingBatch - count}"}`;
 
-  const response = await fetch(GP_GRAPH[network]!, {
+  const response = await fetch(GP_GRAPH[network], {
     method: "POST",
     body: JSON.stringify({
       query: `{


### PR DESCRIPTION
Adds support for xDAI and Rinkeby solutions as well. Mainly adding the different solver addresses, graph endpoints and etherscan URLs for different networks as well as adding a radio selector to the top of the list.

<img width="1295" alt="Screen Shot 2020-10-14 at 13 00 10" src="https://user-images.githubusercontent.com/1200333/95993123-fe242c00-0e2e-11eb-85e9-8488a00a6f98.png">


### Test Plan

Manual testing. At the moment I cannot check if the solutions file are readible, due to some CORS issue with the actual AWS bucket (fetching the list of files fails). I asked DevOps to change the CORS policy and will test before merging.