### PR TITLE
Add support for prod bucket

### DIFF
--- a/src/components/Batch.tsx
+++ b/src/components/Batch.tsx
@@ -125,10 +125,10 @@ function Batch({ batch, network, solutions }: BatchSolutions) {
           <LinkButton title="Instance" classes={classes} href={link}>
             <List />
           </LinkButton>
-          <LinkButton title="Result" classes={classes} href={solver?.result}>
+          <LinkButton title="Result" classes={classes} href={solver?.links?.result}>
             <PlaylistAddCheck />
           </LinkButton>
-          <LinkButton title="Graph" classes={classes} href={solver?.graph}>
+          <LinkButton title="Graph" classes={classes} href={solver?.links?.graph}>
             <DonutLarge />
           </LinkButton>
         </Grid>

--- a/src/models/bucket.ts
+++ b/src/models/bucket.ts
@@ -1,8 +1,14 @@
 import { formatDate } from "../utilities/format";
 import { batchDate } from "./exchange";
 
-const S3_BUCKET = "https://gnosis-dev-dfusion.s3.amazonaws.com";
 const PARSER = new DOMParser();
+
+const STAGING_BUCKET = "gnosis-dev-dfusion";
+const PRODUCTION_BUCKET = "gnosis-europe-dfusion";
+
+function s3Url(bucket: string): string {
+  return `https://${bucket}.s3.amazonaws.com`;
+}
 
 const INSTANCE_CACHE: Record<number, string | undefined> = {};
 let INSTANCE_FIRST_CACHE: Promise<void> | null = null;
@@ -23,15 +29,16 @@ export async function findInstance(batch: number): Promise<string | undefined> {
 }
 
 async function updateInstanceCache(batch: number): Promise<void> {
+  const bucket = STAGING_BUCKET;
   const path = `data/mainnet_dev/standard-solver/instances/${formatDate(
     batchDate(batch),
   )}/`;
-  const instances = (await ls(path))
+  const instances = (await ls(bucket, path))
     .map((path) => /instance_(\d+)_/.exec(path))
     .filter((match) => match)
     .map((match) => ({
       batch: parseInt(match![1]),
-      link: link(match!.input),
+      link: link(bucket, match!.input),
     }));
 
   for (const { batch, link } of instances) {
@@ -41,8 +48,8 @@ async function updateInstanceCache(batch: number): Promise<void> {
 
 export interface ResultData {
   solver: string;
-  result: string;
-  graph: string;
+  result?: string;
+  graph?: string;
 }
 
 export async function findResult(
@@ -54,10 +61,11 @@ export async function findResult(
     return undefined;
   }
 
+  const { bucket } = solverData;
   const path = `data/${solverData.path}/results/${formatDate(
     batchDate(batch),
   )}/`;
-  const resultDir = (await ls(path))
+  const resultDir = (await ls(bucket, path))
     .map((path) => /instance_(\d+)_/.exec(path))
     .filter((match) => match)
     .map((match) => ({
@@ -66,68 +74,83 @@ export async function findResult(
     }))
     .find((resultDir) => resultDir.batch === batch);
   if (!resultDir) {
-    return undefined;
+    return {
+      solver: solverData.name,
+    };
   }
 
   return {
     solver: solverData.name,
-    result: link(`${resultDir.prefix}06_solution_int_valid.json`),
-    graph: link(`${resultDir.prefix}solution-graph.html`),
+    result: link(bucket, `${resultDir.prefix}06_solution_int_valid.json`),
+    graph: link(bucket, `${resultDir.prefix}solution-graph.html`),
   };
 }
 
 interface SolverData {
   name: string;
+  bucket: string;
   path: string;
 }
 
 const SOLVERS: Record<string, SolverData | undefined> = {
   "0x5a30ff01dc11223cff4e99d4263cb6f3aaa69e70": {
     name: "Staging Standard Solver",
+    bucket: STAGING_BUCKET,
     path: "mainnet_dev/standard-solver",
   },
   "0x453ad119f26128034d3b5c2b6179b8b7f63ae1c7": {
     name: "Staging Open Solver",
+    bucket: STAGING_BUCKET,
     path: "mainnet_dev/open-solver",
   },
   "0xe5a93f2ffbc70c39154b09d6511fc612d2f16de4": {
     name: "Staging Best-Ring Solver",
+    bucket: STAGING_BUCKET,
     path: "mainnet_dev/best-ring-solver",
   },
   "0x9ee11fccd3f692d1ddb281d81403b7e08b964c76": {
     name: "Production Standard Solver",
+    bucket: PRODUCTION_BUCKET,
     path: "mainnet_prod/standard-solver",
   },
   "0x0f833795b7597fcb7f22d8278c91ef63d441e949": {
     name: "Production Open Solver",
+    bucket: PRODUCTION_BUCKET,
     path: "mainnet_prod/open-solver",
   },
   "0x665316dabde5c5bc57ad0b2eed523447c5d2a570": {
     name: "Production Best-Ring Solver",
+    bucket: PRODUCTION_BUCKET,
     path: "mainnet_prod/best-ring-solver",
   },
   "0x122085960fe0124569cb99211e6dfad082a10f92": {
     name: "Staging Best-Ring Solver (xDAI)",
+    bucket: STAGING_BUCKET,
     path: "xdai_dev/best-ring-solver",
   },
   "0x03e941626aacd9f088a5d24479f22f2e87045cda": {
     name: "Staging Standard Solver (xDAI)",
+    bucket: STAGING_BUCKET,
     path: "xdai_dev/standard-solver",
   },
   "0x66651c3136f45f5a3f216bdcf794246bdf92163e": {
     name: "Staging Open Solver (xDAI)",
+    bucket: STAGING_BUCKET,
     path: "xdai_dev/open-solver",
   },
   "0xa800b730ca1270a3db0d23c4643363fe795e2fe6": {
     name: "Staging Best-Ring Solver (Rinkeby)",
+    bucket: STAGING_BUCKET,
     path: "rinkeby_dev/best-ring-solver",
   },
   "0x3851195b21d672e88bbd45f0da94e1d14b755339": {
     name: "Staging Standard Solver (Rinkeby)",
+    bucket: STAGING_BUCKET,
     path: "rinkeby_dev/standard-solver",
   },
   "0x8bda84af06bd413f7e47fcbff1b6474b91b41df2": {
     name: "Staging Open Solver (Rinkeby)",
+    bucket: STAGING_BUCKET,
     path: "rinkeby_dev/open-solver",
   },
 };
@@ -136,10 +159,14 @@ function getSolverByAddress(solverAddress: string): SolverData | undefined {
   return SOLVERS[solverAddress.toLowerCase()];
 }
 
-async function ls(path: string, recusive: boolean = false): Promise<string[]> {
+async function ls(
+  bucket: string,
+  path: string,
+  recusive: boolean = false,
+): Promise<string[]> {
   const resurse = recusive ? "" : "list-type=2&delimiter=%2F";
   const prefix = `prefix=${encodeURIComponent(path)}`;
-  const url = `${S3_BUCKET}/?${resurse}&${prefix}`;
+  const url = `${s3Url(bucket)}/?${resurse}&${prefix}`;
 
   const response = await fetch(url);
   const xml = await response.text();
@@ -155,7 +182,7 @@ async function ls(path: string, recusive: boolean = false): Promise<string[]> {
   return items;
 }
 
-function link(path: string): string {
+function link(bucket: string, path: string): string {
   const encoded = encodeURIComponent(path);
-  return `https://gnosis-dev-dfusion.s3.amazonaws.com/${encoded}`;
+  return `${s3Url(bucket)}/${encoded}`;
 }


### PR DESCRIPTION
This PR adds support for separate buckets in production and staging. Futhermore, it no longer marks missing results as "Unknown solver" and just disables the links.

### Test Plan

![image](https://user-images.githubusercontent.com/4210206/96435299-f3d6a900-1205-11eb-910b-8c950ef1ce07.png)

Notice how two solutions are missing results ([5341687](https://etherscan.io/tx/0x6af0f30dc3e4fb1e4888d7109a0d0ccab353aacd5ff734ba1b69c19c16bb142a) and [5341680](https://etherscan.io/tx/0x2e007c52df7e68d36d4cd3046f6f3c8bcf11e612adfb1ae45dcccf9d3edc8ca9)) I was unable to find the results file in either bucket. I suspect they may have been lost during the transition?