### PR TITLE
instance files for correct networks

### DIFF
--- a/src/components/Batch.tsx
+++ b/src/components/Batch.tsx
@@ -73,7 +73,7 @@ function Batch({ batch, network, solutions }: BatchSolutions) {
 
   useEffect(() => {
     const updateLink = async () => {
-      const link = await findInstance(batch);
+      const link = await findInstance(network, batch);
       if (link) {
         setLink(link);
         clearInterval(timer);
@@ -83,7 +83,7 @@ function Batch({ batch, network, solutions }: BatchSolutions) {
     const timer = setInterval(updateLink, LINK_UPDATE_INTERVAL);
     updateLink();
     return () => clearInterval(timer);
-  }, [batch, solutions]);
+  }, [batch, network, solutions]);
 
   const solverAddress = (solutions || [])[0]?.solver;
   useEffect(() => {
@@ -125,10 +125,18 @@ function Batch({ batch, network, solutions }: BatchSolutions) {
           <LinkButton title="Instance" classes={classes} href={link}>
             <List />
           </LinkButton>
-          <LinkButton title="Result" classes={classes} href={solver?.links?.result}>
+          <LinkButton
+            title="Result"
+            classes={classes}
+            href={solver?.links?.result}
+          >
             <PlaylistAddCheck />
           </LinkButton>
-          <LinkButton title="Graph" classes={classes} href={solver?.links?.graph}>
+          <LinkButton
+            title="Graph"
+            classes={classes}
+            href={solver?.links?.graph}
+          >
             <DonutLarge />
           </LinkButton>
         </Grid>

--- a/src/models/bucket.ts
+++ b/src/models/bucket.ts
@@ -1,5 +1,5 @@
 import { formatDate } from "../utilities/format";
-import { batchDate } from "./exchange";
+import { batchDate, Network } from "./exchange";
 
 const PARSER = new DOMParser();
 
@@ -10,32 +10,50 @@ function s3Url(bucket: string): string {
   return `https://${bucket}.s3.amazonaws.com`;
 }
 
-const INSTANCE_CACHE: Record<number, string | undefined> = {};
-let INSTANCE_FIRST_CACHE: Promise<void> | null = null;
-export async function findInstance(batch: number): Promise<string | undefined> {
-  // NOTE: Synchronize the first update of the instance cache. This is done so
-  // that on initial load there aren't multiple requests for listing the
-  // solution instance files on the S3 bucket.
-  if (!INSTANCE_FIRST_CACHE) {
-    INSTANCE_FIRST_CACHE = updateInstanceCache(batch);
-  }
-  await INSTANCE_FIRST_CACHE;
+const INSTANCE_CACHE: Record<Network, Record<number, string | undefined>> = {
+  [Network.Mainnet]: {},
+  [Network.Rinkeby]: {},
+  [Network.Xdai]: {},
+};
+const INSTANCE_CACHE_UPDATE: Record<string, Promise<void> | undefined> = {};
 
-  const cached = INSTANCE_CACHE[batch];
+export async function findInstance(
+  network: Network,
+  batch: number,
+): Promise<string | undefined> {
+  const cached = INSTANCE_CACHE[network][batch];
   if (cached) {
     return cached;
   }
 
-  await updateInstanceCache(batch);
-
-  return INSTANCE_CACHE[batch];
-}
-
-async function updateInstanceCache(batch: number): Promise<void> {
+  // NOTE: Always default to using instance files from the staging standard
+  // solver as, currently, they are the same across all solvers.
   const bucket = STAGING_BUCKET;
-  const path = `data/mainnet_dev/standard-solver/instances/${formatDate(
+  const path = `data/${network}_dev/standard-solver/instances/${formatDate(
     batchDate(batch),
   )}/`;
+
+  // NOTE: Synchronize the updates to the instance cache. This is done so that
+  // on initial load there aren't multiple requests for listing the solution
+  // instance files on the S3 bucket.
+  const updateKey = `${bucket}/${path}`;
+  if (!INSTANCE_CACHE_UPDATE[updateKey]) {
+    INSTANCE_CACHE_UPDATE[updateKey] = updateInstanceCache(
+      bucket,
+      path,
+      network,
+    );
+  }
+  await INSTANCE_CACHE_UPDATE[updateKey];
+
+  return INSTANCE_CACHE[network][batch];
+}
+
+async function updateInstanceCache(
+  bucket: string,
+  path: string,
+  network: Network,
+): Promise<void> {
   const instances = (await ls(bucket, path))
     .map((path) => /instance_(\d+)_/.exec(path))
     .filter((match) => match)
@@ -45,7 +63,7 @@ async function updateInstanceCache(batch: number): Promise<void> {
     }));
 
   for (const { batch, link } of instances) {
-    INSTANCE_CACHE[batch] = link;
+    INSTANCE_CACHE[network][batch] = link;
   }
 }
 

--- a/src/models/bucket.ts
+++ b/src/models/bucket.ts
@@ -34,8 +34,8 @@ export async function findInstance(
   )}/`;
 
   // NOTE: Synchronize the updates to the instance cache. This is done so that
-  // on initial load there aren't multiple requests for listing the solution
-  // instance files on the S3 bucket.
+  // on initial load there aren't multiple requests for listing the instance
+  // files on the S3 bucket.
   const updateKey = `${bucket}/${path}`;
   if (!INSTANCE_CACHE_UPDATE[updateKey]) {
     INSTANCE_CACHE_UPDATE[updateKey] = updateInstanceCache(


### PR DESCRIPTION
Fixes #4 

This PR corrects the instance file links so that they point to the correct network. Previously, instance files would always link to mainnet instances.

### Test Plan

A couple things to note in the screenshot: First is that the file listing is being retrieved for `rinkeby_dev` in the path, further more, there is only one request to the s3 bucket, so synchronization of the updates is working.

![Screenshot from 2020-10-26 11-59-20](https://user-images.githubusercontent.com/4210206/97164796-f6e01500-1782-11eb-8764-cd6e2751edd8.png)
